### PR TITLE
Fix return home url

### DIFF
--- a/Eric/eric.html
+++ b/Eric/eric.html
@@ -9,6 +9,6 @@
 <body>
     <h1>Example page</h1>
     <p>This is an example page.</p>
-    <a href="/index.html">Return home</a>
+    <a href="../index.html">Return home</a>
 </body>
 </html>


### PR DESCRIPTION
GitHub Pages has the repository name in the path part of the URL. So the return home url either needs to include the repo name in a root-relative url, or just use a fully relative url to go to parent directory.
I used the parent directory.